### PR TITLE
Add support for the `in` and `not in` comparator.

### DIFF
--- a/markerpry/node.py
+++ b/markerpry/node.py
@@ -8,7 +8,7 @@ from packaging.version import Version
 from typing_extensions import assert_never, override
 
 Environment = dict[str, list[str | Version | re.Pattern[str] | bool]]
-Comparator = Literal["==", "!=", ">", "<", ">=", "<="]
+Comparator = Literal["==", "!=", ">", "<", ">=", "<=", "in", "not in"]
 
 
 class Node(ABC):

--- a/markerpry/node.py
+++ b/markerpry/node.py
@@ -106,6 +106,10 @@ class ExpressionNode(Node):
             return value == self.rhs
         elif self.comparator == "!=":
             return value != self.rhs
+        elif self.comparator == "in":
+            return value in self.rhs
+        elif self.comparator == "not in":
+            return value not in self.rhs
         else:
             return None
 
@@ -118,6 +122,11 @@ class ExpressionNode(Node):
             return None
 
     def _evaluate_version(self, value: Version) -> "bool | None":
+        if self.comparator in ("in", "not in"):
+            # From: https://peps.python.org/pep-0508/#environment-markers
+            # The <marker_op> operators that are not in <version_cmp> perform
+            # the same as they do for strings in Python
+            return self._evaluate_string(str(value))
         try:
             specifier = SpecifierSet(f"{self.comparator} {self.rhs}")
         except InvalidSpecifier:

--- a/markerpry/parser.py
+++ b/markerpry/parser.py
@@ -43,6 +43,8 @@ def _parse_marker(marker: Any) -> Node:
                     or comparator.value == "<"
                     or comparator.value == ">="
                     or comparator.value == "<="
+                    or comparator.value == "in"
+                    or comparator.value == "not in"
                 )
             ):
                 return ExpressionNode(

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -38,6 +38,18 @@ string_testdata = [
         {"os_name": ["posix"]},
         ExpressionNode(lhs="os_name", comparator=">", rhs="posix"),
     ),
+    (
+        "string_in_operator",
+        ExpressionNode(lhs="os_name", comparator="in", rhs="posix"),
+        {"os_name": ["posix"]},
+        BooleanNode(True),
+    ),
+    (
+        "string_not_in_operator",
+        ExpressionNode(lhs="os_name", comparator="not in", rhs="posix"),
+        {"os_name": ["posix"]},
+        BooleanNode(False),
+    ),
 ]
 
 
@@ -82,6 +94,18 @@ version_testdata = [
         ExpressionNode(lhs="python_version", comparator="<=", rhs="3.8"),
         {"python_version": [Version("3.8")]},
         BooleanNode(True),
+    ),
+    (
+        "version_in_true",
+        ExpressionNode(lhs="python_version", comparator="in", rhs="2.7"),
+        {"python_version": [Version("2.7")]},
+        BooleanNode(True),
+    ),
+    (
+        "version_not_in_false",
+        ExpressionNode(lhs="python_version", comparator="not in", rhs="2.7"),
+        {"python_version": [Version("2.7")]},
+        BooleanNode(False),
     ),
 ]
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,6 +35,14 @@ version_markers = [
         ExpressionNode(lhs="python_version", comparator=">=", rhs="3.8"),
     ),
     (
+        "python_version in '2.7'",
+        ExpressionNode(lhs="python_version", comparator="in", rhs="2.7"),
+    ),
+    (
+        "python_version not in '2.7'",
+        ExpressionNode(lhs="python_version", comparator="not in", rhs="2.7"),
+    ),
+    (
         "python_full_version < '3.9.7'",
         ExpressionNode(lhs="python_full_version", comparator="<", rhs="3.9.7"),
     ),


### PR DESCRIPTION
The `in` and `not in` operators are allowed as defined in the `marker_op` grammer in [PEP-508](https://peps.python.org/pep-0508/). 

It is unclear to me if these are allowed in version markers or not but the only example of use that I've encountered was in an expression with the `python_version` variable, specifically `python_version in "2.7"` from the colander project, https://github.com/Pylons/colander/blob/1.8.0/setup.cfg#L43. 

Given this, I implemented support for evaluation with strings and versions as strings.