### PR TITLE
Fix operator precedence errors

### DIFF
--- a/markerpry/parser.py
+++ b/markerpry/parser.py
@@ -56,21 +56,21 @@ def _parse_marker(marker: Any) -> Node:
                 _left=_parse_marker(marker[0]),
                 _right=_parse_marker(marker[2]),
             )
-        
+
         while len(marker) > 3 and 'and' in marker:
             operator_index = marker.index('and')
-            before = marker[:operator_index-1]
-            term = marker[operator_index-1:operator_index+2]
-            after = marker[operator_index+2:]
+            before = marker[: operator_index - 1]
+            term = marker[operator_index - 1 : operator_index + 2]
+            after = marker[operator_index + 2 :]
             marker = list(before) + [term] + list(after)
 
         while len(marker) > 3 and 'or' in marker:
             operator_index = marker.index('or')
-            before = marker[:operator_index-1]
-            term = marker[operator_index-1:operator_index+2]
-            after = marker[operator_index+2:]
+            before = marker[: operator_index - 1]
+            term = marker[operator_index - 1 : operator_index + 2]
+            after = marker[operator_index + 2 :]
             marker = list(before) + [term] + list(after)
-        
+
         if len(marker) == 3:
             return _parse_marker(marker)
 

--- a/markerpry/parser.py
+++ b/markerpry/parser.py
@@ -50,12 +50,28 @@ def _parse_marker(marker: Any) -> Node:
                     comparator=cast(Comparator, comparator.value),
                     rhs=rhs.value,
                 )
-        if len(marker) >= 3 and (marker[1] == "and" or marker[1] == "or"):
-            rest = _parse_marker(marker[2:])
+        if len(marker) == 3 and (marker[1] == "and" or marker[1] == "or"):
             return OperatorNode(
                 operator=marker[1],
                 _left=_parse_marker(marker[0]),
-                _right=rest,
+                _right=_parse_marker(marker[2]),
             )
+        
+        while len(marker) > 3 and 'and' in marker:
+            operator_index = marker.index('and')
+            before = marker[:operator_index-1]
+            term = marker[operator_index-1:operator_index+2]
+            after = marker[operator_index+2:]
+            marker = list(before) + [term] + list(after)
+
+        while len(marker) > 3 and 'or' in marker:
+            operator_index = marker.index('or')
+            before = marker[:operator_index-1]
+            term = marker[operator_index-1:operator_index+2]
+            after = marker[operator_index+2:]
+            marker = list(before) + [term] + list(after)
+        
+        if len(marker) == 3:
+            return _parse_marker(marker)
 
     raise NotImplementedError(f"Unknown marker {type(marker)}: {marker}")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -119,16 +119,16 @@ complex_and_markers = [
         "python_version >= '3.8' and (os_name == 'posix' and platform_machine == 'x86_64') and python_version < '4.0'",
         OperatorNode(
             operator="and",
-            _left=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.8"),
-            _right=OperatorNode(
+            _left=OperatorNode(
                 operator="and",
-                _right=ExpressionNode(lhs="python_version", comparator="<", rhs="4.0"),
-                _left=OperatorNode(
+                _left=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.8"),
+                _right=OperatorNode(
                     operator="and",
                     _left=ExpressionNode(lhs="os_name", comparator="==", rhs="posix"),
                     _right=ExpressionNode(lhs="platform_machine", comparator="==", rhs="x86_64"),
                 ),
             ),
+            _right=ExpressionNode(lhs="python_version", comparator="<", rhs="4.0"),
         ),
     ),
     (
@@ -212,25 +212,25 @@ mixed_op_markers = [
     (
         "os_name == 'nt' and python_version >= '3.8' or platform_machine == 'x86_64'",
         OperatorNode(
-            operator="and",
-            _left=ExpressionNode(lhs="os_name", comparator="==", rhs="nt"),
-            _right=OperatorNode(
-                operator="or",
-                _left=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.8"),
-                _right=ExpressionNode(lhs="platform_machine", comparator="==", rhs="x86_64"),
+            operator="or",
+            _left=OperatorNode(
+                operator="and",
+                _left=ExpressionNode(lhs="os_name", comparator="==", rhs="nt"),
+                _right=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.8"),
             ),
+            _right=ExpressionNode(lhs="platform_machine", comparator="==", rhs="x86_64"),
         ),
     ),
     (
         "os_name == 'nt' or python_version >= '3.8' or platform_machine == 'x86_64'",
         OperatorNode(
             operator="or",
-            _left=ExpressionNode(lhs="os_name", comparator="==", rhs="nt"),
-            _right=OperatorNode(
+            _left=OperatorNode(
                 operator="or",
-                _left=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.8"),
-                _right=ExpressionNode(lhs="platform_machine", comparator="==", rhs="x86_64"),
+                _left=ExpressionNode(lhs="os_name", comparator="==", rhs="nt"),
+                _right=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.8"),
             ),
+            _right=ExpressionNode(lhs="platform_machine", comparator="==", rhs="x86_64"),
         ),
     ),
 ]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -240,3 +240,109 @@ mixed_op_markers = [
 def test_mixed_op_markers(marker_str: str, expected):
     result = parse(marker_str)
     assert result == expected
+
+
+# Operator precedence and associativity tests
+precedence_testdata = [
+    (
+        "left_associative_and",
+        "python_version >= '3.7' and os_name == 'posix' and implementation_name == 'cpython'",
+        OperatorNode(
+            operator="and",
+            _left=OperatorNode(
+                operator="and",
+                _left=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.7"),
+                _right=ExpressionNode(lhs="os_name", comparator="==", rhs="posix"),
+            ),
+            _right=ExpressionNode(lhs="implementation_name", comparator="==", rhs="cpython"),
+        ),
+    ),
+    (
+        "left_associative_or",
+        "python_version >= '3.7' or os_name == 'posix' or implementation_name == 'cpython'",
+        OperatorNode(
+            operator="or",
+            _left=OperatorNode(
+                operator="or",
+                _left=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.7"),
+                _right=ExpressionNode(lhs="os_name", comparator="==", rhs="posix"),
+            ),
+            _right=ExpressionNode(lhs="implementation_name", comparator="==", rhs="cpython"),
+        ),
+    ),
+    (
+        "and_higher_precedence_than_or",
+        "python_version >= '3.7' or os_name == 'posix' and implementation_name == 'cpython'",
+        OperatorNode(
+            operator="or",
+            _left=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.7"),
+            _right=OperatorNode(
+                operator="and",
+                _left=ExpressionNode(lhs="os_name", comparator="==", rhs="posix"),
+                _right=ExpressionNode(lhs="implementation_name", comparator="==", rhs="cpython"),
+            ),
+        ),
+    ),
+    (
+        "and_higher_precedence_multiple",
+        "python_version >= '3.7' or os_name == 'posix' and implementation_name == 'cpython' or sys_platform == 'linux'",
+        OperatorNode(
+            operator="or",
+            _left=OperatorNode(
+                operator="or",
+                _left=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.7"),
+                _right=OperatorNode(
+                    operator="and",
+                    _left=ExpressionNode(lhs="os_name", comparator="==", rhs="posix"),
+                    _right=ExpressionNode(lhs="implementation_name", comparator="==", rhs="cpython"),
+                ),
+            ),
+            _right=ExpressionNode(lhs="sys_platform", comparator="==", rhs="linux"),
+        ),
+    ),
+    (
+        "mixed_precedence_complex",
+        "python_version >= '3.7' and os_name == 'posix' or implementation_name == 'cpython' and sys_platform == 'linux'",
+        OperatorNode(
+            operator="or",
+            _left=OperatorNode(
+                operator="and",
+                _left=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.7"),
+                _right=ExpressionNode(lhs="os_name", comparator="==", rhs="posix"),
+            ),
+            _right=OperatorNode(
+                operator="and",
+                _left=ExpressionNode(lhs="implementation_name", comparator="==", rhs="cpython"),
+                _right=ExpressionNode(lhs="sys_platform", comparator="==", rhs="linux"),
+            ),
+        ),
+    ),
+    (
+        "explicit_precedence_matches_implicit",
+        "(python_version >= '3.7' and os_name == 'posix') or (implementation_name == 'cpython' and sys_platform == 'linux')",
+        OperatorNode(
+            operator="or",
+            _left=OperatorNode(
+                operator="and",
+                _left=ExpressionNode(lhs="python_version", comparator=">=", rhs="3.7"),
+                _right=ExpressionNode(lhs="os_name", comparator="==", rhs="posix"),
+            ),
+            _right=OperatorNode(
+                operator="and",
+                _left=ExpressionNode(lhs="implementation_name", comparator="==", rhs="cpython"),
+                _right=ExpressionNode(lhs="sys_platform", comparator="==", rhs="linux"),
+            ),
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name,marker_str,expected",
+    precedence_testdata,
+    ids=[x[0] for x in precedence_testdata],
+)
+def test_operator_precedence(name: str, marker_str: str, expected: Node):
+    """Test that operator precedence and associativity rules are correctly applied."""
+    result = parse(marker_str)
+    assert result == expected

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -71,10 +71,7 @@ def test_multiple_and_to_str():
         'python_version >= "3.8" and os_name == "posix" and '
         'platform_machine == "x86_64" and implementation_name == "cpython"'
     )
-    expected = (
-        '(python_version >= "3.8" and (os_name == "posix" and ('
-        'platform_machine == "x86_64" and implementation_name == "cpython")))'
-    )
+    expected = '(((python_version >= "3.8" and os_name == "posix") and platform_machine == "x86_64") and implementation_name == "cpython")'
     expr = parse(marker_str)
     assert str(expr) == expected
 
@@ -82,7 +79,7 @@ def test_multiple_and_to_str():
 def test_multiple_or_to_str():
     # Test with multiple OR operators
     marker_str = 'os_name == "posix" or os_name == "nt" or ' 'os_name == "darwin" or os_name == "aix"'
-    expected = '(os_name == "posix" or (os_name == "nt" or (' 'os_name == "darwin" or os_name == "aix")))'
+    expected = '(((os_name == "posix" or os_name == "nt") or os_name == "darwin") or os_name == "aix")'
     expr = parse(marker_str)
     assert str(expr) == expected
 


### PR DESCRIPTION
`a or b and c` should be parsed as `a or (b and c)`

Although it's not specified at all in the PEP https://peps.python.org/pep-0508/#environment-markers
We can infer from the examples that: `and` has higher precedence than `or`, otherwise it's left-associative.

This fixes the logic to match. For the underlying packaging.markers implementation, it doesn't handle this directly when parsing. Instead, if you have `a or b and c`, you end up with an array of `[a, or, b, and, c]` so we need to implement the logic properly ourselves.

The easiest solution is to make a two pass through the array, replacing `a and b` with `(a and b)` first, and then `a or b` with `(a or b)` second to enforce evaluation order