### PR TITLE
Make the nodes more pythonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ The parse method returns a tree where each node is one of:
 
 ### Tree Navigation
 
-The tree can be navigated using the `left` and `right` properties of nodes:
+The tree can be navigated using the `left` and `right` properties of nodes. These properties
+return `None` for leaf nodes (BooleanNode and ExpressionNode):
 
 ```python
 # For operator nodes (and/or), access child nodes
@@ -54,6 +55,23 @@ right_expr = tree.right # (os_name == "posix" or platform_system == "Linux")
 # For nested expressions, continue traversing
 nested_left = right_expr.left  # os_name == "posix"
 nested_right = right_expr.right  # platform_system == "Linux"
+
+# Leaf nodes have no children
+assert nested_left.left is None
+assert nested_left.right is None
+```
+
+### Checking for Keys
+
+You can check if a marker expression contains a specific environment key using the `in` operator:
+
+```python
+# Check if a marker depends on specific environment keys
+tree = parse('python_version >= "3.7" and os_name == "posix"')
+
+assert "python_version" in tree
+assert "os_name" in tree
+assert "platform_machine" not in tree
 ```
 
 ### String Representation

--- a/markerpry/node.py
+++ b/markerpry/node.py
@@ -33,14 +33,10 @@ class Node(ABC):
     def right(self) -> "Node | None":
         return None
 
-    def contains(self, key: str) -> bool:
-        if self.left is not None:
-            if self.left.contains(key):
-                return True
-        if self.right is not None:
-            if self.right.contains(key):
-                return True
-        return False
+    @abstractmethod
+    def __contains__(self, key: str) -> bool:
+        """Return whether this node contains the given key."""
+        pass
 
 
 @dataclass(frozen=True)
@@ -56,6 +52,10 @@ class BooleanNode(Node):
     @override
     def evaluate(self, environment: Environment) -> "Node":
         return self  # No need to create new BooleanNode since they're immutable
+
+    @override
+    def __contains__(self, key: str) -> bool:
+        return False  # BooleanNode never contains any keys
 
 
 TRUE = BooleanNode(True)
@@ -75,8 +75,8 @@ class ExpressionNode(Node):
         return f'{self.lhs} {self.comparator} "{self.rhs}"'
 
     @override
-    def contains(self, key: str) -> bool:
-        return self.lhs == key
+    def __contains__(self, key: str) -> bool:
+        return self.lhs == key  # ExpressionNode contains only its lhs key
 
     @override
     def evaluate(self, environment: Environment) -> "Node":
@@ -179,3 +179,8 @@ class OperatorNode(Node):
             return OperatorNode(self.operator, left, right)
         else:
             assert_never(self.operator)
+
+    @override
+    def __contains__(self, key: str) -> bool:
+        # OperatorNode contains keys from both children
+        return key in self._left or key in self._right

--- a/markerpry/node.py
+++ b/markerpry/node.py
@@ -38,6 +38,13 @@ class Node(ABC):
         """Return whether this node contains the given key."""
         pass
 
+    def __bool__(self) -> bool:
+        """
+        Prevent accidental boolean coercion of non-boolean nodes.
+        Only BooleanNode should be used in boolean contexts.
+        """
+        raise TypeError(f"Cannot convert {self.__class__.__name__} to bool - use evaluate() first")
+
 
 @dataclass(frozen=True)
 class BooleanNode(Node):
@@ -56,6 +63,17 @@ class BooleanNode(Node):
     @override
     def __contains__(self, key: str) -> bool:
         return False  # BooleanNode never contains any keys
+
+    def __bool__(self) -> bool:
+        return self.state
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, BooleanNode):
+            return self.state == other.state
+        if isinstance(other, bool):
+            return bool(self) == other
+        return NotImplemented
 
 
 TRUE = BooleanNode(True)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -4,19 +4,19 @@ from markerpry.node import FALSE, TRUE, BooleanNode, ExpressionNode, OperatorNod
 def test_boolean_node_contains():
     """Test that BooleanNode never contains any keys."""
     node = BooleanNode(True)
-    assert not node.contains("python_version")
-    assert not node.contains("os_name")
-    assert not node.contains("")
+    assert "python_version" not in node
+    assert "os_name" not in node
+    assert "" not in node
 
 
 def test_expression_node_contains():
     """Test that ExpressionNode contains only its lhs key."""
     expr = ExpressionNode("python_version", ">=", "3.7")
-
-    assert expr.contains("python_version")
-    assert not expr.contains("os_name")
-    assert not expr.contains("python_implementation")
-    assert not expr.contains("")
+    
+    assert "python_version" in expr
+    assert "os_name" not in expr
+    assert "python_implementation" not in expr
+    assert "" not in expr
 
 
 def test_operator_node_contains():
@@ -24,11 +24,11 @@ def test_operator_node_contains():
     expr1 = ExpressionNode("python_version", ">=", "3.7")
     expr2 = ExpressionNode("os_name", "==", "posix")
     and_node = OperatorNode("and", expr1, expr2)
-
-    assert and_node.contains("python_version")
-    assert and_node.contains("os_name")
-    assert not and_node.contains("python_implementation")
-    assert not and_node.contains("")
+    
+    assert "python_version" in and_node
+    assert "os_name" in and_node
+    assert "python_implementation" not in and_node
+    assert "" not in and_node
 
 
 def test_operator_node_nested_contains():
@@ -38,12 +38,12 @@ def test_operator_node_nested_contains():
     and_node = OperatorNode("and", expr1, expr2)
     expr3 = ExpressionNode("implementation_name", "==", "cpython")
     or_node = OperatorNode("or", and_node, expr3)
-
-    assert or_node.contains("python_version")
-    assert or_node.contains("os_name")
-    assert or_node.contains("implementation_name")
-    assert not or_node.contains("platform_machine")
-    assert not or_node.contains("")
+    
+    assert "python_version" in or_node
+    assert "os_name" in or_node
+    assert "implementation_name" in or_node
+    assert "platform_machine" not in or_node
+    assert "" not in or_node
 
 
 def test_operator_node_with_boolean_contains():
@@ -51,10 +51,10 @@ def test_operator_node_with_boolean_contains():
     expr = ExpressionNode("python_version", ">=", "3.7")
     true_node = BooleanNode(True)
     and_node = OperatorNode("and", true_node, expr)
-
-    assert and_node.contains("python_version")
-    assert not and_node.contains("os_name")
-    assert not and_node.contains("")
+    
+    assert "python_version" in and_node
+    assert "os_name" not in and_node
+    assert "" not in and_node
 
 
 def test_boolean_equality():

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,5 +1,6 @@
-from markerpry.node import FALSE, TRUE, BooleanNode, ExpressionNode, OperatorNode
 import pytest
+
+from markerpry.node import FALSE, TRUE, BooleanNode, ExpressionNode, OperatorNode
 
 
 def test_boolean_node_contains():
@@ -13,7 +14,7 @@ def test_boolean_node_contains():
 def test_expression_node_contains():
     """Test that ExpressionNode contains only its lhs key."""
     expr = ExpressionNode("python_version", ">=", "3.7")
-    
+
     assert "python_version" in expr
     assert "os_name" not in expr
     assert "python_implementation" not in expr
@@ -25,7 +26,7 @@ def test_operator_node_contains():
     expr1 = ExpressionNode("python_version", ">=", "3.7")
     expr2 = ExpressionNode("os_name", "==", "posix")
     and_node = OperatorNode("and", expr1, expr2)
-    
+
     assert "python_version" in and_node
     assert "os_name" in and_node
     assert "python_implementation" not in and_node
@@ -39,7 +40,7 @@ def test_operator_node_nested_contains():
     and_node = OperatorNode("and", expr1, expr2)
     expr3 = ExpressionNode("implementation_name", "==", "cpython")
     or_node = OperatorNode("or", and_node, expr3)
-    
+
     assert "python_version" in or_node
     assert "os_name" in or_node
     assert "implementation_name" in or_node
@@ -52,7 +53,7 @@ def test_operator_node_with_boolean_contains():
     expr = ExpressionNode("python_version", ">=", "3.7")
     true_node = BooleanNode(True)
     and_node = OperatorNode("and", true_node, expr)
-    
+
     assert "python_version" in and_node
     assert "os_name" not in and_node
     assert "" not in and_node
@@ -102,15 +103,15 @@ def test_non_boolean_node_coercion():
 
     with pytest.raises(TypeError, match="Cannot convert ExpressionNode to bool"):
         bool(expr)
-    
+
     with pytest.raises(TypeError, match="Cannot convert OperatorNode to bool"):
         bool(op)
-    
+
     # Test in if statement
     with pytest.raises(TypeError, match="Cannot convert ExpressionNode to bool"):
         if expr:
             pass
-    
+
     with pytest.raises(TypeError, match="Cannot convert OperatorNode to bool"):
         if op:
             pass

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,4 +1,5 @@
 from markerpry.node import FALSE, TRUE, BooleanNode, ExpressionNode, OperatorNode
+import pytest
 
 
 def test_boolean_node_contains():
@@ -58,7 +59,58 @@ def test_operator_node_with_boolean_contains():
 
 
 def test_boolean_equality():
+    """Test boolean node equality with both BooleanNodes and Python bools."""
     assert BooleanNode(True) == BooleanNode(True)
     assert BooleanNode(True) != BooleanNode(False)
     assert TRUE == TRUE
     assert BooleanNode(True) == TRUE
+    # New tests for bool comparison
+    assert TRUE == True  # type: ignore
+    assert FALSE == False  # type: ignore
+    assert TRUE != False  # type: ignore
+    assert FALSE != True  # type: ignore
+
+
+def test_boolean_coercion():
+    """Test that BooleanNode can be used in boolean contexts."""
+    assert bool(TRUE) is True
+    assert bool(FALSE) is False
+    # Test in if statement
+    if TRUE:
+        assert True
+    else:
+        assert False
+    if FALSE:
+        assert False
+    else:
+        assert True
+    # Test with and/or
+    assert TRUE and True
+    assert not (FALSE and True)
+    assert TRUE or False
+    assert not (FALSE or False)
+
+
+def test_non_boolean_node_coercion():
+    """Test that non-boolean nodes cannot be coerced to bool."""
+    expr = ExpressionNode("python_version", ">=", "3.7")
+    op = OperatorNode(
+        "and",
+        ExpressionNode("os_name", "==", "posix"),
+        ExpressionNode("python_version", ">=", "3.7"),
+    )
+
+    with pytest.raises(TypeError, match="Cannot convert ExpressionNode to bool"):
+        bool(expr)
+    
+    with pytest.raises(TypeError, match="Cannot convert OperatorNode to bool"):
+        bool(op)
+    
+    # Test in if statement
+    with pytest.raises(TypeError, match="Cannot convert ExpressionNode to bool"):
+        if expr:
+            pass
+    
+    with pytest.raises(TypeError, match="Cannot convert OperatorNode to bool"):
+        if op:
+            pass


### PR DESCRIPTION
Implement `in` instead of the contains method.
Make sure a BooleanNode is castable to a bool, and can check equality.
Prevent other node types from being directly coerced to a bool, instead requiring if Node is None