### PR TITLE
add a 'resolved' attribute

### DIFF
--- a/markerpry/node.py
+++ b/markerpry/node.py
@@ -33,6 +33,10 @@ class Node(ABC):
     def right(self) -> "Node | None":
         return None
 
+    @property
+    def resolved(self) -> bool:
+        return False
+
     @abstractmethod
     def __contains__(self, key: str) -> bool:
         """Return whether this node contains the given key."""
@@ -66,6 +70,11 @@ class BooleanNode(Node):
 
     def __bool__(self) -> bool:
         return self.state
+
+    @override
+    @property
+    def resolved(self) -> bool:
+        return True
 
     @override
     def __eq__(self, other: object) -> bool:

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -63,6 +63,39 @@ def test_string_evaluate(name: str, expr: ExpressionNode, env: Environment, expe
     assert result == expected
 
 
+# Resolved attribute tests
+resolved_testdata = [
+    (
+        "string_equality_true",
+        ExpressionNode(lhs="os_name", comparator="==", rhs="posix"),
+        {"os_name": ["posix"]},
+        True,
+    ),
+    (
+        "string_equality_false",
+        ExpressionNode(lhs="os_name", comparator="==", rhs="nt"),
+        {"os_name": ["posix"]},
+        True,
+    ),
+    (
+        "string_equality_incomplete",
+        ExpressionNode(lhs="os_name", comparator="==", rhs="nt"),
+        {"python_version": [Version("3.7")]},
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name,expr,env,expected",
+    resolved_testdata,
+    ids=[x[0] for x in resolved_testdata],
+)
+def test_resolved_attribute_on_evaluate(name: str, expr: ExpressionNode, env: Environment, expected: bool):
+    result = expr.evaluate(env)
+    assert result.resolved == expected
+
+
 # Version comparison tests
 version_testdata = [
     (

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -92,6 +92,21 @@ def test_boolean_coercion():
     assert not (FALSE or False)
 
 
+def test_resolved_attribute():
+    """Test that the resolved attribute is True iff a node is a BooleanNode"""
+    assert BooleanNode(True).resolved == True
+    assert BooleanNode(False).resolved == True
+    ExpressionNode("python_version", ">=", "3.7").resolved == False
+    assert (
+        OperatorNode(
+            "and",
+            ExpressionNode("os_name", "==", "posix"),
+            ExpressionNode("python_version", ">=", "3.7"),
+        ).resolved
+        == False
+    )
+
+
 def test_non_boolean_node_coercion():
     """Test that non-boolean nodes cannot be coerced to bool."""
     expr = ExpressionNode("python_version", ">=", "3.7")


### PR DESCRIPTION
The 'resolved' attribute is a boolean indicating if a marker expression has been fully resolved during evaluation.

This is equivalent to checking if the tree is a BooleanNode.