### PR TITLE
Allow markerpry to parse ~= and in/not in  operators

### DIFF
--- a/markerpry/parser.py
+++ b/markerpry/parser.py
@@ -56,6 +56,7 @@ def _parse_marker(marker: Any) -> Node:
                 and isinstance(comparator, Op)
                 and (
                     comparator.value == "=="
+                    or comparator.value == "==="
                     or comparator.value == "!="
                     or comparator.value == ">"
                     or comparator.value == "<"
@@ -63,7 +64,19 @@ def _parse_marker(marker: Any) -> Node:
                     or comparator.value == "<="
                     or comparator.value == "in"
                     or comparator.value == "not in"
+                    or comparator.value == "~="
                 )
+            ):
+                return ExpressionNode(
+                    lhs=lhs.value,
+                    comparator=cast(Comparator, comparator.value),
+                    rhs=rhs.value,
+                )
+            if (
+                isinstance(lhs, Value)
+                and isinstance(rhs, Variable)
+                and isinstance(comparator, Op)
+                and (comparator.value == "in" or comparator.value == "not in")
             ):
                 return ExpressionNode(
                     lhs=lhs.value,

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -115,3 +115,181 @@ def test_non_boolean_node_coercion():
     with pytest.raises(TypeError, match="Cannot convert OperatorNode to bool"):
         if op:
             pass
+
+
+# In/NotIn operator tests
+in_operator_testdata = [
+    (
+        "in_check_rhs",
+        ExpressionNode(lhs="value", comparator="in", rhs="python_version"),
+        "python_version",
+        True,  # Should check rhs
+    ),
+    (
+        "in_check_lhs",
+        ExpressionNode(lhs="value", comparator="in", rhs="python_version"),
+        "value",
+        False,  # lhs is not a dependency
+    ),
+    (
+        "in_check_other",
+        ExpressionNode(lhs="value", comparator="in", rhs="python_version"),
+        "other_key",
+        False,  # other keys not included
+    ),
+    (
+        "not_in_check_rhs",
+        ExpressionNode(lhs="value", comparator="not in", rhs="python_version"),
+        "python_version",
+        True,  # Should check rhs
+    ),
+    (
+        "not_in_check_lhs",
+        ExpressionNode(lhs="value", comparator="not in", rhs="python_version"),
+        "value",
+        False,  # lhs is not a dependency
+    ),
+    (
+        "not_in_check_other",
+        ExpressionNode(lhs="value", comparator="not in", rhs="python_version"),
+        "other_key",
+        False,  # other keys not included
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name,expr,key,expected",
+    in_operator_testdata,
+    ids=[x[0] for x in in_operator_testdata],
+)
+def test_in_operator_contains(name: str, expr: ExpressionNode, key: str, expected: bool):
+    """Test that 'in' and 'not in' expressions check the correct keys."""
+    assert (key in expr) == expected
+
+
+# String representation tests for in/not in
+in_str_testdata = [
+    (
+        "in_version",
+        ExpressionNode(lhs="3.7", comparator="in", rhs="python_version"),
+        '"3.7" in python_version',
+    ),
+    (
+        "in_platform",
+        ExpressionNode(lhs="linux", comparator="in", rhs="sys_platform"),
+        '"linux" in sys_platform',
+    ),
+    (
+        "not_in_version",
+        ExpressionNode(lhs="3.7", comparator="not in", rhs="python_version"),
+        '"3.7" not in python_version',
+    ),
+    (
+        "not_in_platform",
+        ExpressionNode(lhs="linux", comparator="not in", rhs="sys_platform"),
+        '"linux" not in sys_platform',
+    ),
+    (
+        "triple_equal_version",
+        ExpressionNode(lhs="python_version", comparator="===", rhs="3.7"),
+        'python_version === "3.7"',
+    ),
+    (
+        "triple_equal_platform",
+        ExpressionNode(lhs="sys_platform", comparator="===", rhs="linux"),
+        'sys_platform === "linux"',
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name,expr,expected_str",
+    in_str_testdata,
+    ids=[x[0] for x in in_str_testdata],
+)
+def test_in_operator_str(name: str, expr: ExpressionNode, expected_str: str):
+    """Test string representation of 'in' and 'not in' expressions."""
+    assert str(expr) == expected_str
+
+
+# Expression node contains tests
+expression_contains_testdata = [
+    (
+        "normal_comparison_lhs",
+        ExpressionNode(lhs="python_version", comparator=">=", rhs="3.7"),
+        "python_version",
+        True,  # lhs is the key for normal comparisons
+    ),
+    (
+        "normal_comparison_rhs",
+        ExpressionNode(lhs="python_version", comparator=">=", rhs="3.7"),
+        "3.7",
+        False,  # rhs is not a key for normal comparisons
+    ),
+    (
+        "in_operator_lhs",
+        ExpressionNode(lhs="3.7", comparator="in", rhs="python_version"),
+        "3.7",
+        False,  # lhs is not a key for 'in' operator
+    ),
+    (
+        "in_operator_rhs",
+        ExpressionNode(lhs="3.7", comparator="in", rhs="python_version"),
+        "python_version",
+        True,  # rhs is the key for 'in' operator
+    ),
+    (
+        "not_in_operator_lhs",
+        ExpressionNode(lhs="3.7", comparator="not in", rhs="python_version"),
+        "3.7",
+        False,  # lhs is not a key for 'not in' operator
+    ),
+    (
+        "not_in_operator_rhs",
+        ExpressionNode(lhs="3.7", comparator="not in", rhs="python_version"),
+        "python_version",
+        True,  # rhs is the key for 'not in' operator
+    ),
+    (
+        "normal_comparison_other",
+        ExpressionNode(lhs="python_version", comparator=">=", rhs="3.7"),
+        "other_key",
+        False,  # unrelated keys are never contained
+    ),
+    (
+        "in_operator_other",
+        ExpressionNode(lhs="3.7", comparator="in", rhs="python_version"),
+        "other_key",
+        False,  # unrelated keys are never contained
+    ),
+    (
+        "triple_equal_lhs",
+        ExpressionNode(lhs="python_version", comparator="===", rhs="3.7"),
+        "python_version",
+        True,  # lhs is the key for triple equal comparison
+    ),
+    (
+        "triple_equal_rhs",
+        ExpressionNode(lhs="python_version", comparator="===", rhs="3.7"),
+        "3.7",
+        False,  # rhs is not a key for triple equal comparison
+    ),
+    (
+        "triple_equal_other",
+        ExpressionNode(lhs="python_version", comparator="===", rhs="3.7"),
+        "other_key",
+        False,  # unrelated keys are never contained
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name,expr,key,expected",
+    expression_contains_testdata,
+    ids=[x[0] for x in expression_contains_testdata],
+)
+def test_expression_contains(name: str, expr: ExpressionNode, key: str, expected: bool):
+    """Test that __contains__ works correctly for all expression types."""
+    assert (key in expr) == expected
+

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -292,4 +292,3 @@ expression_contains_testdata = [
 def test_expression_contains(name: str, expr: ExpressionNode, key: str, expected: bool):
     """Test that __contains__ works correctly for all expression types."""
     assert (key in expr) == expected
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -354,3 +354,38 @@ def test_operator_precedence(name: str, marker_str: str, expected: Node):
     """Test that operator precedence and associativity rules are correctly applied."""
     result = parse(marker_str)
     assert result == expected
+
+
+# Real-world marker string tests
+real_world_markers = [
+    (
+        "tilde_match_version",
+        'python_version ~= "3.7"',
+    ),
+    (
+        "triple_equal_version",
+        'python_version === "3.7"',
+    ),
+    ('in syntax', '"windows" in sys_platform'),
+]
+
+
+@pytest.mark.parametrize(
+    "name,marker_str",
+    real_world_markers,
+    ids=[x[0] for x in real_world_markers],
+)
+def test_real_world_markers_roundtrip(name: str, marker_str: str):
+    """Test that real-world marker strings can be parsed and converted back to strings."""
+    from packaging.markers import Marker
+
+    # Verify the marker is valid according to packaging
+    Marker(marker_str)
+
+    # Parse and convert back to string
+    tree = parse(marker_str)
+    result_str = str(tree)
+
+    # Parse the result string again to verify it produces the same tree
+    result_tree = parse(result_str)
+    assert result_tree == tree

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -112,3 +112,41 @@ def test_simplify():
     node = parse(marker_str)
     simplified = node.evaluate({"implementation_name": ["pypy"]})
     assert str(Marker(str(simplified))).replace('"', "'") == 'os_name == "posix"'.replace('"', "'")
+
+# In/NotIn operator roundtrip tests
+in_operator_roundtrip_testdata = [
+    (
+        "in_version",
+        '"3.7" in python_version',
+        "python_version",
+    ),
+    (
+        "in_platform",
+        '"linux" in sys_platform',
+        "sys_platform",
+    ),
+    (
+        "not_in_version",
+        '"3.7" not in python_version',
+        "python_version",
+    ),
+    (
+        "not_in_platform",
+        '"linux" not in sys_platform',
+        "sys_platform",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name,marker_str,expected_key",
+    in_operator_roundtrip_testdata,
+    ids=[x[0] for x in in_operator_roundtrip_testdata],
+)
+def test_in_operator_roundtrip(name: str, marker_str: str, expected_key: str):
+    """Test that 'in' and 'not in' expressions can be parsed and formatted correctly."""
+    node = parse(marker_str)
+    # Test string roundtrip
+    assert str(node) == marker_str
+    # Test dependency key is preserved
+    assert expected_key in node

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -113,6 +113,7 @@ def test_simplify():
     simplified = node.evaluate({"implementation_name": ["pypy"]})
     assert str(Marker(str(simplified))).replace('"', "'") == 'os_name == "posix"'.replace('"', "'")
 
+
 # In/NotIn operator roundtrip tests
 in_operator_roundtrip_testdata = [
     (


### PR DESCRIPTION
From testing markerpry against PyPI, here are some bugs that need fixing:

First, there are two more operators that need supporting  - `===` and `~=`. For now we'll treat `===` and `==` the same.
Secondly, the `in/not in` operator needs more logic support since the key is on the right hand side. This fixes the parsing, as well as the string representation to properly handle this