### PR TITLE
add parse_marker function

### DIFF
--- a/markerpry/__init__.py
+++ b/markerpry/__init__.py
@@ -12,7 +12,7 @@ from .node import (
     Node,
     OperatorNode,
 )
-from .parser import parse
+from .parser import parse, parse_marker
 
 __all__ = [
     "Node",
@@ -20,6 +20,7 @@ __all__ = [
     "ExpressionNode",
     "OperatorNode",
     "parse",
+    "parse_marker",
     "Environment",
     "Comparator",
     "TRUE",

--- a/markerpry/parser.py
+++ b/markerpry/parser.py
@@ -20,6 +20,19 @@ def parse(marker_str: str) -> Node:
         packaging.markers.InvalidMarker: If the marker string is invalid
     """
     marker = Marker(marker_str)
+    return parse_marker(marker)
+
+
+def parse_marker(marker: Marker) -> Node:
+    """
+    Parse a packaging.marker.Marker object into a Node tree.
+
+    Args:
+        marker: A packaging.marker.Marker instance.
+
+    Returns:
+        A Node representing the parsed marker expression
+    """
     return _parse_marker(marker._markers)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,7 +2,7 @@ import pytest
 from packaging.markers import Marker
 
 from markerpry.node import BooleanNode, ExpressionNode, Node, OperatorNode
-from markerpry.parser import parse
+from markerpry.parser import parse, parse_marker
 
 # Basic comparison tests
 basic_markers = [
@@ -389,3 +389,9 @@ def test_real_world_markers_roundtrip(name: str, marker_str: str):
     # Parse the result string again to verify it produces the same tree
     result_tree = parse(result_str)
     assert result_tree == tree
+
+
+def test_parse_marker():
+    marker = Marker("os_name == 'nt'")
+    result = parse_marker(marker)
+    assert result == ExpressionNode(lhs="os_name", comparator="==", rhs="nt")


### PR DESCRIPTION
Add a parse_marker function that allow parsing a Marker object.

This avoids an unneeded conversion back to string if the expression has already been parsed by packaging.