### PR TITLE
Fixes reversed markers so they evaluate the same way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run tests
         run: hatch run test
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: |
@@ -41,7 +41,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download coverage report
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage-report
       - name: Display coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         run: pipx install hatch
       - name: Build the release
         run: hatch build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: |
@@ -41,7 +41,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -395,22 +395,22 @@ reversed_comparator_testdata = [
     (
         "reversed_greater_than",
         '"3.0" < python_version',
-        ExpressionNode(lhs="python_version", comparator=">=", rhs="3.0"),
+        ExpressionNode(lhs="python_version", comparator=">", rhs="3.0"),
     ),
     (
         "reversed_less_than",
         '"3.0" > python_version',
-        ExpressionNode(lhs="python_version", comparator="<=", rhs="3.0"),
+        ExpressionNode(lhs="python_version", comparator="<", rhs="3.0"),
     ),
     (
         "reversed_greater_equal",
         '"3.0" <= python_version',
-        ExpressionNode(lhs="python_version", comparator=">", rhs="3.0"),
+        ExpressionNode(lhs="python_version", comparator=">=", rhs="3.0"),
     ),
     (
         "reversed_less_equal",
         '"3.0" >= python_version',
-        ExpressionNode(lhs="python_version", comparator="<", rhs="3.0"),
+        ExpressionNode(lhs="python_version", comparator="<=", rhs="3.0"),
     ),
     (
         "reversed_equal",

--- a/tests/test_reverse_map.py
+++ b/tests/test_reverse_map.py
@@ -1,0 +1,40 @@
+import pytest
+from packaging.markers import Marker
+
+from markerpry.parser import REVERSE_MAP
+
+test_cases: list[tuple[str, str, dict[str, str]]] = []
+for op, reverse_op in REVERSE_MAP.items():
+    if op == "~=":
+        continue
+
+    # Test with a value before, equal to, and after 3.7
+    for version in ["3.6", "3.7", "3.8"]:
+        test_cases.append(
+            (
+                f'python_version {op} "3.7"',
+                f'"3.7" {reverse_op} python_version',
+                {"python_version": version},
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "marker_str,reversed_marker_str,env",
+    test_cases,
+)
+def test_reverse_map_equivalence(marker_str: str, reversed_marker_str: str, env: dict[str, str]):
+    """Test that a marker and its reversed form evaluate to the same result."""
+    # For example: python < "3.7" should evaluate the same as "3.7" > python
+    # where the new operator comes from REVERSE_MAP
+    marker = Marker(marker_str)
+    reversed_marker = Marker(reversed_marker_str)
+
+    result = marker.evaluate(env)
+    reversed_result = reversed_marker.evaluate(env)
+
+    assert result == reversed_result, (
+        f"Markers not equivalent for env={env}:\n"
+        f"{marker_str} evaluated to {result}\n"
+        f"{reversed_marker_str} evaluated to {reversed_result}"
+    )


### PR DESCRIPTION
If the marker was 3.7 > python_version, the correct equivalency is python_version < 3.7, not <=. This adds an explicit test against the Marker.evaluate function, and ensures the reversed version evaluates the same