### PR TITLE
Fix reversed marker for in/not in

### DIFF
--- a/markerpry/parser.py
+++ b/markerpry/parser.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 from types import MappingProxyType
-from typing import Any
+from typing import Any, cast
 
 from packaging._parser import Op, Value, Variable
 from packaging.markers import Marker
@@ -97,19 +97,22 @@ def _parse_marker(marker: Any) -> Node:
             ):
                 if comparator.value in ('in', 'not in'):
                     return ExpressionNode(
-                        lhs=lhs.value, comparator=comparator.value, rhs=rhs.value, inverted=isinstance(lhs, Variable)
+                        lhs=lhs.value,
+                        comparator=cast(Comparator, comparator.value),
+                        rhs=rhs.value,
+                        inverted=isinstance(lhs, Variable),
                     )
                 if isinstance(lhs, Value):
                     # The marker is reversed, e.g. "3.0" < python_version
                     # Flip it around to simplify the logic
                     return ExpressionNode(
                         lhs=rhs.value,
-                        comparator=REVERSE_MAP[comparator.value],
+                        comparator=REVERSE_MAP[cast(Comparator, comparator.value)],
                         rhs=lhs.value,
                     )
                 return ExpressionNode(
                     lhs=lhs.value,
-                    comparator=comparator.value,
+                    comparator=cast(Comparator, comparator.value),
                     rhs=rhs.value,
                 )
 

--- a/markerpry/parser.py
+++ b/markerpry/parser.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any
 
 from packaging._parser import Op, Value, Variable
 from packaging.markers import Marker
@@ -79,8 +79,8 @@ def _parse_marker(marker: Any) -> Node:
                     _right=_parse_marker(rhs),
                 )
             if (
-                isinstance(lhs, Variable)
-                and isinstance(rhs, Value)
+                isinstance(lhs, (Variable, Value))
+                and isinstance(rhs, (Variable, Value))
                 and isinstance(comparator, Op)
                 and (
                     comparator.value == "=="
@@ -91,46 +91,26 @@ def _parse_marker(marker: Any) -> Node:
                     or comparator.value == ">="
                     or comparator.value == "<="
                     or comparator.value == "~="
+                    or comparator.value == "in"
+                    or comparator.value == "not in"
                 )
             ):
+                if comparator.value in ('in', 'not in'):
+                    return ExpressionNode(
+                        lhs=lhs.value, comparator=comparator.value, rhs=rhs.value, inverted=isinstance(lhs, Variable)
+                    )
+                if isinstance(lhs, Value):
+                    # The marker is reversed, e.g. "3.0" < python_version
+                    # Flip it around to simplify the logic
+                    return ExpressionNode(
+                        lhs=rhs.value,
+                        comparator=REVERSE_MAP[comparator.value],
+                        rhs=lhs.value,
+                    )
                 return ExpressionNode(
                     lhs=lhs.value,
-                    comparator=cast(Comparator, comparator.value),
+                    comparator=comparator.value,
                     rhs=rhs.value,
                 )
-            if (
-                isinstance(lhs, Value)
-                and isinstance(rhs, Variable)
-                and isinstance(comparator, Op)
-                and (
-                    comparator.value == "=="
-                    or comparator.value == "==="
-                    or comparator.value == "!="
-                    or comparator.value == ">"
-                    or comparator.value == "<"
-                    or comparator.value == ">="
-                    or comparator.value == "<="
-                    or comparator.value == "~="
-                )
-            ):
-                # The marker has e.g. "3.0" < python_version
-                # Which is equivalent to python_version > "3.0"
-                # Switch it here so we don't deal with this edge case after parsing
-                reverse_comparator = REVERSE_MAP[cast(Comparator, comparator.value)]
-                return ExpressionNode(
-                    lhs=rhs.value,
-                    comparator=reverse_comparator,
-                    rhs=lhs.value,
-                )
-            if (
-                isinstance(lhs, Value)
-                and isinstance(rhs, Variable)
-                and isinstance(comparator, Op)
-                and (comparator.value == "in" or comparator.value == "not in")
-            ):
-                return ExpressionNode(
-                    lhs=lhs.value,
-                    comparator=cast(Comparator, comparator.value),
-                    rhs=rhs.value,
-                )
+
     raise NotImplementedError(f"Unknown marker {type(marker)}: {marker}")

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,6 +1,7 @@
 import re
 
 import pytest
+from packaging.markers import Marker
 from packaging.version import Version
 
 from markerpry.node import BooleanNode, Environment, ExpressionNode, Node, OperatorNode
@@ -40,13 +41,19 @@ string_testdata = [
     ),
     (
         "string_in_operator",
-        ExpressionNode(lhs="os_name", comparator="in", rhs="posix"),
+        ExpressionNode(lhs="posix", comparator="in", rhs="os_name"),
         {"os_name": ["posix"]},
         BooleanNode(True),
     ),
     (
-        "string_not_in_operator",
-        ExpressionNode(lhs="os_name", comparator="not in", rhs="posix"),
+        "inverted_string_in_operator",
+        ExpressionNode(lhs="os_name", comparator="in", rhs="posix", inverted=True),
+        {"os_name": ["posix"]},
+        BooleanNode(True),
+    ),
+    (
+        "inverted_string_not_in_operator",
+        ExpressionNode(lhs="os_name", comparator="not in", rhs="posix", inverted=True),
         {"os_name": ["posix"]},
         BooleanNode(False),
     ),
@@ -130,13 +137,25 @@ version_testdata = [
     ),
     (
         "version_in_true",
-        ExpressionNode(lhs="python_version", comparator="in", rhs="2.7"),
+        ExpressionNode(lhs="2.7", comparator="in", rhs="python_version"),
+        {"python_version": [Version("2.7")]},
+        BooleanNode(True),
+    ),
+    (
+        "inverted_version_in_true",
+        ExpressionNode(lhs="python_version", comparator="in", rhs="2.7", inverted=True),
         {"python_version": [Version("2.7")]},
         BooleanNode(True),
     ),
     (
         "version_not_in_false",
-        ExpressionNode(lhs="python_version", comparator="not in", rhs="2.7"),
+        ExpressionNode(lhs="2.7", comparator="not in", rhs="python_version"),
+        {"python_version": [Version("2.7")]},
+        BooleanNode(False),
+    ),
+    (
+        "inverted_version_not_in_false",
+        ExpressionNode(lhs="python_version", comparator="not in", rhs="2.7", inverted=True),
         {"python_version": [Version("2.7")]},
         BooleanNode(False),
     ),
@@ -612,3 +631,205 @@ full_eval_testdata = [
 def test_full_evaluation(name: str, expr: OperatorNode, env: Environment, expected: Node):
     result = expr.evaluate(env)
     assert result == expected
+
+
+# Comparison tests with packaging.Marker
+packaging_comparison_testdata = [
+    # Basic in/not in tests
+    (
+        "in_no_match",
+        '"2.7" in python_version',
+        {"python_version": ["2.6"]},
+        False,
+    ),
+    (
+        "in_exact_match",
+        '"2.7" in python_version',
+        {"python_version": ["2.7"]},
+        True,
+    ),
+    (
+        "in_partial_match",
+        '"2." in python_version',
+        {"python_version": ["2.7"]},
+        True,
+    ),
+    (
+        "not_in_match",
+        '"2.7" not in python_version',
+        {"python_version": ["3.6"]},
+        True,
+    ),
+    # Basic in/not in tests using Version specs
+    (
+        "in_no_match",
+        '"2.7" in python_version',
+        {"python_version": [Version("2.6")]},
+        False,
+    ),
+    (
+        "in_exact_match",
+        '"2.7" in python_version',
+        {"python_version": [Version("2.7")]},
+        True,
+    ),
+    (
+        "in_partial_match",
+        '"2." in python_version',
+        {"python_version": [Version("2.7")]},
+        True,
+    ),
+    (
+        "not_in_match",
+        '"2.7" not in python_version',
+        {"python_version": [Version("3.6")]},
+        True,
+    ),
+    # Inverted in/not in tests
+    (
+        "in_no_match_inverted",
+        '"2.7" not in python_version',
+        {"python_version": ["3.6"]},
+        True,
+    ),
+    (
+        "in_exact_match_inverted",
+        '"2.7" not in python_version',
+        {"python_version": ["2.7"]},
+        False,
+    ),
+    (
+        "inverted_in_partial_match",
+        'python_version in "2."',
+        {"python_version": ["2.7"]},
+        False,
+    ),
+    (
+        "inverted_not_in_match",
+        'python_version not in "2.7"',
+        {"python_version": ["3.6"]},
+        True,
+    ),
+    # Version comparison tests
+    (
+        "version_equals",
+        'python_version == "3.7"',
+        {"python_version": ["3.7"]},
+        True,
+    ),
+    (
+        "version_not_equals",
+        'python_version != "3.7"',
+        {"python_version": ["3.8"]},
+        True,
+    ),
+    (
+        "version_greater_than",
+        'python_version > "3.7"',
+        {"python_version": [Version("3.8")]},
+        True,
+    ),
+    (
+        "version_less_than",
+        'python_version < "3.7"',
+        {"python_version": [Version("3.6")]},
+        True,
+    ),
+    (
+        "version_greater_equal",
+        'python_version >= "3.7"',
+        {"python_version": [Version("3.7")]},
+        True,
+    ),
+    (
+        "version_less_equal",
+        'python_version <= "3.7"',
+        {"python_version": [Version("3.7")]},
+        True,
+    ),
+    # Complex version tests
+    (
+        "version_micro_level",
+        'python_version == "3.7.2"',
+        {"python_version": [Version("3.7.2")]},
+        True,
+    ),
+    (
+        "version_pre_release",
+        'python_version == "3.7.0b2"',
+        {"python_version": [Version("3.7.0b2")]},
+        True,
+    ),
+    (
+        "version_post_release",
+        'python_version == "3.7.0.post1"',
+        {"python_version": [Version("3.7.0.post1")]},
+        True,
+    ),
+    # Multiple version comparisons
+    (
+        "version_and",
+        'python_version >= "3.6" and python_version < "4.0"',
+        {"python_version": [Version("3.7")]},
+        True,
+    ),
+    (
+        "version_or",
+        'python_version < "3.0" or python_version >= "3.6"',
+        {"python_version": [Version("3.7")]},
+        True,
+    ),
+    # Edge cases
+    (
+        "version_zero",
+        'python_version == "0.0"',
+        {"python_version": [Version("0.0")]},
+        True,
+    ),
+    (
+        "version_dev",
+        'python_version == "3.7.0.dev1"',
+        {"python_version": [Version("3.7.0.dev1")]},
+        True,
+    ),
+    (
+        "version_local",
+        'python_version == "3.7.0+local"',
+        {"python_version": [Version("3.7.0+local")]},
+        True,
+    ),
+    # Mixed environment tests
+    (
+        "mixed_version_and_platform",
+        'python_version >= "3.6" and sys_platform == "linux"',
+        {"python_version": [Version("3.7")], "sys_platform": ["linux"]},
+        True,
+    ),
+    (
+        "mixed_version_and_implementation",
+        'python_version >= "3.6" and implementation_name == "cpython"',
+        {"python_version": [Version("3.7")], "implementation_name": ["cpython"]},
+        True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name,marker_str,env,expected",
+    packaging_comparison_testdata,
+    ids=[x[0] for x in packaging_comparison_testdata],
+)
+def test_packaging_comparison(name: str, marker_str: str, env: Environment, expected: bool):
+    """Test that our evaluation matches packaging.Marker's evaluation."""
+    # Parse and evaluate with our implementation
+    our_node = parse(marker_str)
+    our_result = our_node.evaluate(env)
+    assert isinstance(our_result, BooleanNode)
+    assert our_result.state == expected
+
+    # Evaluate with packaging.Marker
+    packaging_marker = Marker(marker_str)
+    # Convert our environment format to packaging's format
+    packaging_env = {k: str(v[0]) for k, v in env.items()}
+    packaging_result = packaging_marker.evaluate(packaging_env)
+    assert packaging_result == expected


### PR DESCRIPTION
It is possible to have a marker which is reversed using in/not in syntax such as python_version in 2.7.
Parse this condition properly and handle related bugs around in/out.

The main fix here is to use the `inverted` flag to indicate a non-normal `in` operator. E.g. `python_version in 2.7`. When this happens the lhs and rhs need to get flipped for all parts of the node object, including str() handling, and evaluating.

Additionally, the evaluation for `in/not in` needs to be changed to either check thing in value or value in thing depending on which way the original evaluation node is.

Added a bunch of tests to catch these cases

Fixes #11 